### PR TITLE
Trim wildcard labels and read input line-at-a-time

### DIFF
--- a/cmd/dnslol/main.go
+++ b/cmd/dnslol/main.go
@@ -108,12 +108,12 @@ func reverseName(domain string) string {
 }
 
 // isDNSCharacter returns true if the given byte is a valid character for a DNS
-// name.
+// name, or is a wildcard label ("*").
 func isDNSCharacter(ch byte) bool {
 	return ('a' <= ch && ch <= 'z') ||
 		('A' <= ch && ch <= 'Z') ||
 		('0' <= ch && ch <= '9') ||
-		ch == '.' || ch == '-'
+		ch == '.' || ch == '-' || ch == '*'
 }
 
 // isValidName returns true if the given name only has valid DNS characters.

--- a/cmd/dnslol/main.go
+++ b/cmd/dnslol/main.go
@@ -205,7 +205,7 @@ func main() {
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Fatal(err)
+		log.Fatalf("Error reading names from standard input: %s\n", err)
 	}
 
 	// Close the names channel and wait for the experiment to be finished

--- a/dnslol/dnslol.go
+++ b/dnslol/dnslol.go
@@ -150,6 +150,8 @@ func (e Experiment) runQueries(dnsClient *dns.Client, name string) error {
 		return errors.New("runQueries requires a non-nil dnsClient instance")
 	}
 
+	name = strings.TrimLeft(name, "*.")
+
 	// Build the queries for this name for each of the nameservers
 	queries := e.buildQueries(name)
 


### PR DESCRIPTION
If dnslol gets a wildcard domain name as input, it will strip the wildcard label and just look up the part that is a valid DNS name.

Also, this reads input one line at a time to avoid running out of memory on big inputs.